### PR TITLE
Fix path detection in worker

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ You can also define a "due date" (UNIX Timestamp) for your job. Your job will be
 ## Options and opinionated defaults
 
 ```php
-option("bvdputte.kirbyqueue.roots");
+option("bvdputte.kirbyqueue.root");
 ```
 
 The default folder name for the queues is `queues`. This will be placed in the `/site/` folder.

--- a/worker.php
+++ b/worker.php
@@ -3,8 +3,8 @@
 use bvdputte\kirbyQueue\Queueworker;
 
 // Bootstrap Kirby (from with the plugin's folder)
-require '../../../kirby/bootstrap.php';
-$kirbyPath = dirname(__FILE__) . "/../../../../";
+$kirbyPath = realpath(__DIR__ . "/../../../");
+require $kirbyPath . '/kirby/bootstrap.php';
 
 // Instantiate Kirby
 $kirby = new Kirby([


### PR DESCRIPTION
Very handy plugin, thanks!

Currently running the plugin only works if started from the plugin’s folder. Now the worker can be started form any directory and paths are calculated automatically.

Also the root is called roots in the readme. This also fixed in this PR.